### PR TITLE
Bug Fix: Ensure weapons are loaded when INCLUDE_DLC and DLC_EXCLUSIVES are both true

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -113,7 +113,7 @@ function toggleDLCWeaponCheckbox(isEnabled) {
 
 //checks both ashes and weapons, loaded in dlc-exclusives
 function isDLCExclusive(name) {
-    return INCLUDE_DLC.checked && DLC_EXCLUSIVES.has(name);
+    return !INCLUDE_DLC.checked && DLC_EXCLUSIVES.has(name);
 }
 
 function onlyDLCExclusives(name) {


### PR DESCRIPTION
Hi,
sorry to bother you, not even a week later, but  I just noticed that I have done the refactor of the function `isDLCExclusive` incorrectly.

When INCLUDE_DLC and DLC_EXCLUSIVES were both true it was suppose to return false, returned true instead. This results in no weapons being added to the wheel.

Original function
```javascript
function isDLCExclusive(name){
    if(INCLUDE_DLC.checked){
        return false;
    }
    return DLC_EXCLUSIVES[name]; // true if dlc weapon false otherwise
}
```

Translation:
```javascript
function isDLCExclusive(name){
    return INCLUDE_DLC.checked && DLC_EXCLUSIVES.has(name); // true if dlc weapon false otherwise
}
```

Fix, inverted INCLUDE_DLC.checked. This now correctly only returns true if the weapons is a DLC-Weapon and the DLC is not included.


Kind regards 
Artem
